### PR TITLE
Implement another way to compare expected weariness transitions

### DIFF
--- a/tests/weary_test.cpp
+++ b/tests/weary_test.cpp
@@ -103,7 +103,7 @@ TEST_CASE( "weary_assorted_tasks", "[weary][activities]" )
         INFO( info.summarize() );
         INFO( guy.debug_weary_info() );
         REQUIRE( !info.empty() );
-        CHECK( info.is_transition_at( 370_minutes, 0, 1, 5_minutes ) );
+        CHECK( info.transition_minutes( 0, 1 ) == Approx( 370 ).margin( 5 ) );
         CHECK( guy.weariness_level() == 1 );
     }
 
@@ -113,10 +113,10 @@ TEST_CASE( "weary_assorted_tasks", "[weary][activities]" )
         INFO( info.summarize() );
         INFO( guy.debug_weary_info() );
         REQUIRE( !info.empty() );
-        CHECK( info.is_transition_at( 115_minutes, 0, 1 ) );
-        CHECK( info.is_transition_at( 255_minutes, 1, 2 ) );
-        CHECK( info.is_transition_at( 360_minutes, 2, 3, 5_minutes ) );
-        CHECK( info.is_transition_at( 465_minutes, 3, 4, 5_minutes ) );
+        CHECK( info.transition_minutes( 0, 1 ) == Approx( 115 ).margin( 0 ) );
+        CHECK( info.transition_minutes( 1, 2 ) == Approx( 255 ).margin( 0 ) );
+        CHECK( info.transition_minutes( 2, 3 ) == Approx( 360 ).margin( 5 ) );
+        CHECK( info.transition_minutes( 3, 4 ) == Approx( 465 ).margin( 5 ) );
         CHECK( guy.weariness_level() == 4 );
 
         INFO( "\nDigging Pits 12 hours:" );
@@ -124,11 +124,11 @@ TEST_CASE( "weary_assorted_tasks", "[weary][activities]" )
         INFO( info.summarize() );
         INFO( guy.debug_weary_info() );
         REQUIRE( !info.empty() );
-        CHECK( info.is_transition_at( 110_minutes, 0, 1 ) );
-        CHECK( info.is_transition_at( 250_minutes, 1, 2 ) );
-        CHECK( info.is_transition_at( 355_minutes, 2, 3, 5_minutes ) );
-        CHECK( info.is_transition_at( 460_minutes, 3, 4, 5_minutes ) );
-        CHECK( info.is_transition_at( 580_minutes, 4, 5, 5_minutes ) );
+        CHECK( info.transition_minutes( 0, 1 ) == Approx( 110 ).margin( 0 ) );
+        CHECK( info.transition_minutes( 1, 2 ) == Approx( 250 ).margin( 0 ) );
+        CHECK( info.transition_minutes( 2, 3 ) == Approx( 355 ).margin( 5 ) );
+        CHECK( info.transition_minutes( 3, 4 ) == Approx( 460 ).margin( 5 ) );
+        CHECK( info.transition_minutes( 4, 5 ) == Approx( 580 ).margin( 5 ) );
         CHECK( guy.weariness_level() == 5 );
     }
 }
@@ -154,8 +154,8 @@ TEST_CASE( "weary_recovery", "[weary][activities]" )
         INFO( info.summarize() );
         INFO( guy.debug_weary_info() );
         REQUIRE( !info.empty() );
-        CHECK( info.is_transition_at( 700_minutes, 4, 3 ) );
-        CHECK( info.is_transition_at( 820_minutes, 3, 2 ) );
+        CHECK( info.transition_minutes( 4, 3 ) == Approx( 700 ).margin( 0 ) );
+        CHECK( info.transition_minutes( 3, 2 ) == Approx( 820 ).margin( 0 ) );
         CHECK( guy.weariness_level() == 2 );
     }
 }
@@ -189,14 +189,14 @@ TEST_CASE( "weary_24h_tasks", "[weary][activities]" )
         INFO( info.summarize() );
         INFO( guy.debug_weary_info() );
         REQUIRE( !info.empty() );
-        CHECK( info.is_transition_at( 125_minutes, 0, 1 ) );
-        CHECK( info.is_transition_at( 260_minutes, 1, 2 ) );
-        CHECK( info.is_transition_at( 360_minutes, 2, 3 ) );
-        CHECK( info.is_transition_at( 460_minutes, 3, 4, 5_minutes ) );
-        CHECK( info.is_transition_at( 585_minutes, 4, 5, 5_minutes ) );
-        CHECK( info.is_transition_at( 725_minutes, 5, 6, 5_minutes ) );
-        CHECK( info.is_transition_at( 835_minutes, 6, 7, 5_minutes ) );
-        CHECK( info.is_transition_at( 905_minutes, 7, 8, 5_minutes ) );
+        CHECK( info.transition_minutes( 0, 1 ) == Approx( 125 ).margin( 0 ) );
+        CHECK( info.transition_minutes( 1, 2 ) == Approx( 260 ).margin( 0 ) );
+        CHECK( info.transition_minutes( 2, 3 ) == Approx( 360 ).margin( 0 ) );
+        CHECK( info.transition_minutes( 3, 4 ) == Approx( 460 ).margin( 5 ) );
+        CHECK( info.transition_minutes( 4, 5 ) == Approx( 585 ).margin( 5 ) );
+        CHECK( info.transition_minutes( 5, 6 ) == Approx( 725 ).margin( 5 ) );
+        CHECK( info.transition_minutes( 6, 7 ) == Approx( 835 ).margin( 5 ) );
+        CHECK( info.transition_minutes( 7, 8 ) == Approx( 905 ).margin( 5 ) );
         // TODO: You should collapse from this - currently we
         // just get really high levels of weariness
         CHECK( guy.weariness_level() > 8 );

--- a/tests/weary_test.h
+++ b/tests/weary_test.h
@@ -101,6 +101,16 @@ struct weariness_events {
             return false;
         }
 
+        // Return the first time a transition between `from` and `to` occurs, in minutes
+        int transition_minutes( const int from, const int to ) const {
+            for( const weary_transition &change : transitions ) {
+                if( change.from == from && change.to == to ) {
+                    return change.minutes;
+                }
+            }
+            return 0;
+        }
+
         std::string summarize() const {
             std::string buffer;
             for( const weary_transition &change : transitions ) {


### PR DESCRIPTION
Rather than do the approximation margin calculation inside `is_transition_at`, this alternative adds a `transition_minutes` function that returns the number of minutes where the given weariness transition first occurs in the weariness_events. This allows the CHECKs to use builtin Catch2 features for `Approx()` and `margin()`.

This will make test failures a little more readable, since the `CHECK` macros will have some numbers to work with, instead of just the boolean result of `is_transition_at`. For example, before this change, a failure would look like this:

```
weary_test.cpp:192: FAILED:
  CHECK( info.is_transition_at( 120_minutes, 0, 1 ) )
with expansion:                                                
  false
```

After, you'll get more info:

```
weary_test.cpp:192: FAILED:
  CHECK( info.transition_minutes( 0, 1 ) == Approx( 120 ).margin( 0 ) )
with expansion:
  125 == Approx( 120.0 )
```
